### PR TITLE
Do not run zcash builds as part of image construction.

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -18,7 +18,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 # Build for linux in docker
-docker run --rm -v $(pwd):/opt/zcash adityapk00/zcash:latest bash -c "cd /opt/zcash-linux && git pull && CONFIGURE_FLAGS=\"--disable-tests --disable-mining --disable-bench\" ./zcutil/build.sh -j$(nproc) && strip src/zcashd && strip src/zcash-cli && cp src/zcashd src/zcash-cli /opt/zcash/artifacts/linux/"
+docker run --rm -v $(pwd):/opt/zcash adityapk00/zcash:latest bash -c "cd /opt/zcash-linux && git fetch && git reset --hard origin/zecwallet-build && CONFIGURE_FLAGS=\"--disable-tests --disable-mining --disable-bench\" ./zcutil/build.sh -j$(nproc) && strip src/zcashd && strip src/zcash-cli && cp src/zcashd src/zcash-cli /opt/zcash/artifacts/linux/"
 
 # Build for win in docker
-docker run --rm -v $(pwd):/opt/zcash adityapk00/zcash:latest bash -c "cd /opt/zcash-win && git pull && CONFIGURE_FLAGS=\"--disable-tests --disable-mining --disable-bench\" HOST=x86_64-w64-mingw32 ./zcutil/build.sh -j$(nproc) && strip src/zcashd.exe && strip src/zcash-cli.exe && cp src/zcashd.exe src/zcash-cli.exe /opt/zcash/artifacts/win/"
+docker run --rm -v $(pwd):/opt/zcash adityapk00/zcash:latest bash -c "cd /opt/zcash-win && git fetch && git reset --hard origin/zecwallet-build && CONFIGURE_FLAGS=\"--disable-tests --disable-mining --disable-bench\" HOST=x86_64-w64-mingw32 ./zcutil/build.sh -j$(nproc) && strip src/zcashd.exe && strip src/zcash-cli.exe && cp src/zcashd.exe src/zcash-cli.exe /opt/zcash/artifacts/win/"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,10 +13,6 @@ RUN mkdir ~/.cargo && \
     echo "linker = \"x86_64-w64-mingw32-gcc\"" >> ~/.cargo/config && \
     echo "ar = \"x86_64-w64-mingw32-gcc-ar\""  >> ~/.cargo/config
 
-RUN cd /opt && git clone https://github.com/adityapk00/zcash.git zcash-linux && cd zcash-linux && \
-    git checkout zecwallet-build && \
-    CONFIGURE_FLAGS="--disable-tests --disable-mining --disable-bench" ./zcutil/build.sh -j$(nproc) 
-
-RUN cd /opt && git clone https://github.com/adityapk00/zcash.git zcash-win && cd zcash-win && \
-    git checkout zecwallet-build && \
-    CONFIGURE_FLAGS="--disable-tests --disable-mining --disable-bench" HOST=x86_64-w64-mingw32 ./zcutil/build.sh -j$(nproc)  
+RUN cd /opt && git clone https://github.com/adityapk00/zcash.git zcash-build && cd zcash-build && \
+    git worktree add --detach ../zcash-linux origin/zecwallet-build && \
+    git worktree add --detach ../zcash-win origin/zecwallet-build


### PR DESCRIPTION
This just performs a little minor cleanup on the Dockerfile, to ensure that build artifacts are not left in place across builds. This also uses git worktrees to avoid redundant download and storage of git data, and uses `git reset --hard` instead of `git pull` to avoid inadvertent merges.